### PR TITLE
デフォルトで暗号化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ export const backupAuth = onSchedule(
 | region     | required | asia-northeast1                     |
 | projectId  | optional | process.env.GCLOUD_PROJECT          |
 | bucketName | optional | ${projectId}-authentication-backups |
-| encrypt    | optional | false                               |
+| encrypt    | optional | true                                |
 
 ## npm publish
 

--- a/src/backupAuth.ts
+++ b/src/backupAuth.ts
@@ -8,7 +8,7 @@ export const backupAuth = async ({
   region,
   projectId = process.env.GCLOUD_PROJECT,
   bucketName = `${process.env.GCLOUD_PROJECT}-authentication-backups`,
-  encrypt,
+  encrypt = true,
 }: {
   region: string;
   projectId?: string;
@@ -17,7 +17,8 @@ export const backupAuth = async ({
 }): Promise<void> => {
   const plaintextFileName = `firebase-authentication-backup.csv`;
   const tmpPlaintextFileName = `/tmp/${plaintextFileName}`;
-  const gcsDestination = `${new Date().toISOString()}/${plaintextFileName}.encrypted`;
+  const gcsDirectoryName = new Date().toISOString();
+  const gcsDestination = encrypt ? `${gcsDirectoryName}/${plaintextFileName}.encrypted` : `${gcsDirectoryName}/${plaintextFileName}`;
 
   // ローカルに取得
   await auth.export(tmpPlaintextFileName, { project: projectId });


### PR DESCRIPTION
#8 の作り直し

README のコードだと暗号化されないので、うっかり平文でバックアップしてしまいそう。
基本的には暗号化するものだと思うので、明示的にオプションを指定しなければ暗号化するようにしました。